### PR TITLE
Add GET (show) endpoint for MenuItemReviewMenu item review get show

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.example.controllers;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import edu.ucsb.cs156.example.entities.MenuItemReview;
+import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import edu.ucsb.cs156.example.repositories.MenuItemReviewRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,6 +32,19 @@ public class MenuItemReviewController extends ApiController {
   public Iterable<MenuItemReview> allMenuItemReviews() {
     Iterable<MenuItemReview> reviews = menuItemReviewRepository.findAll();
     return reviews;
+  }
+
+  @Operation(summary = "Get a single review")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("")
+  public MenuItemReview getById(@Parameter(name = "id") @RequestParam Long id)
+      throws JsonProcessingException {
+    MenuItemReview review =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    return review;
   }
 
   @Operation(summary = "Create a new review")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -1,6 +1,7 @@
 package edu.ucsb.cs156.example.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,6 +17,8 @@ import edu.ucsb.cs156.example.testconfig.TestConfig;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -28,7 +31,6 @@ import org.springframework.test.web.servlet.MvcResult;
 public class MenuItemReviewControllerTests extends ControllerTestCase {
 
   @MockBean MenuItemReviewRepository menuItemReviewRepository;
-
   @MockBean UserRepository userRepository;
 
   // -------------------------------------------------------------------------
@@ -68,6 +70,59 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
     String expectedJson = mapper.writeValueAsString(expectedReviews);
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
+  }
+
+  // -------------------------------------------------------------------------
+  // Tests for GET /api/MenuItemReview?id=...
+  // -------------------------------------------------------------------------
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_getById_returns_review_if_it_exists() throws Exception {
+
+    // arrange
+    LocalDateTime ldt = LocalDateTime.parse("2022-01-03T00:00:00");
+    MenuItemReview review =
+        MenuItemReview.builder()
+            .itemId(1L)
+            .reviewerEmail("arjun@ucsb.edu")
+            .stars(5)
+            .dateReviewed(ldt)
+            .comments("Amazing")
+            .build();
+
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.of(review));
+
+    // act
+    MvcResult response =
+        mockMvc.perform(get("/api/MenuItemReview?id=7")).andExpect(status().isOk()).andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    String expectedJson = mapper.writeValueAsString(review);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_getById_returns_404_if_it_does_not_exist() throws Exception {
+
+    // arrange
+    when(menuItemReviewRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/MenuItemReview?id=7"))
+            .andExpect(status().isNotFound())
+            .andReturn();
+
+    // assert
+    verify(menuItemReviewRepository, times(1)).findById(eq(7L));
+    Map<String, Object> json = responseToJson(response);
+    assertEquals("EntityNotFoundException", json.get("type"));
+    assertEquals("MenuItemReview with id 7 not found", json.get("message"));
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
In this PR, the GET (show) endpoint is added to the `MenuItemReviewController`. 
This allows a user to retrieve a single review by its `id`.

### Changes:
* Added `getById` method to `MenuItemReviewController`.
* Added tests for both the success case (id exists) and the error case (id does not exist).
* Verified 100% test coverage and mutation coverage for the new code.

Closes #28 