### PR TITLE
Add PUT (edit) endpoint for MenuItemReview

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/MenuItemReviewController.java
@@ -17,6 +17,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import jakarta.validation.Valid;
 
 @Tag(name = "MenuItemReview")
 @RequestMapping("/api/MenuItemReview")
@@ -47,6 +50,28 @@ public class MenuItemReviewController extends ApiController {
     return review;
   }
 
+  @Operation(summary = "Update a single review")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PutMapping("")
+  public MenuItemReview updateMenuItemReview(
+      @Parameter(name = "id") @RequestParam Long id,
+      @RequestBody @Valid MenuItemReview incoming) {
+
+    MenuItemReview review =
+        menuItemReviewRepository
+            .findById(id)
+            .orElseThrow(() -> new EntityNotFoundException(MenuItemReview.class, id));
+
+    review.setItemId(incoming.getItemId());
+    review.setReviewerEmail(incoming.getReviewerEmail());
+    review.setStars(incoming.getStars());
+    review.setDateReviewed(incoming.getDateReviewed());
+    review.setComments(incoming.getComments());
+
+    menuItemReviewRepository.save(review);
+
+    return review;
+  }
   @Operation(summary = "Create a new review")
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @PostMapping("/post")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/MenuItemReviewControllerTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.http.MediaType;
 
 @WebMvcTest(controllers = MenuItemReviewController.class)
 @Import(TestConfig.class)
@@ -123,7 +124,74 @@ public class MenuItemReviewControllerTests extends ControllerTestCase {
     Map<String, Object> json = responseToJson(response);
     assertEquals("EntityNotFoundException", json.get("type"));
     assertEquals("MenuItemReview with id 7 not found", json.get("message"));
-  }
+  } 
+
+    // -------------------------------------------------------------------------
+  // Tests for PUT 
+  // -------------------------------------------------------------------------
+
+  @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_edit_an_existing_menuitemreview() throws Exception {
+        // arrange
+        LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+        LocalDateTime ldt2 = LocalDateTime.parse("2023-01-03T00:00:00");
+
+        MenuItemReview reviewOrig = MenuItemReview.builder()
+                .itemId(1L).reviewerEmail("old@ucsb.edu").stars(3)
+                .dateReviewed(ldt1).comments("Old Comment").build();
+
+        MenuItemReview reviewChanged = MenuItemReview.builder()
+                .itemId(2L).reviewerEmail("new@ucsb.edu").stars(5)
+                .dateReviewed(ldt2).comments("New Comment").build();
+
+        String requestBody = mapper.writeValueAsString(reviewChanged);
+
+        when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.of(reviewOrig));
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/MenuItemReview?id=67")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+
+        // assert
+        verify(menuItemReviewRepository, times(1)).findById(67L);
+        verify(menuItemReviewRepository, times(1)).save(reviewChanged);
+        String responseString = response.getResponse().getContentAsString();
+        assertEquals(mapper.writeValueAsString(reviewChanged), responseString);
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_cannot_edit_menuitemreview_that_does_not_exist() throws Exception {
+        // arrange
+        LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+        MenuItemReview reviewChanged = MenuItemReview.builder()
+                .itemId(2L).reviewerEmail("new@ucsb.edu").stars(5)
+                .dateReviewed(ldt1).comments("New Comment").build();
+
+        String requestBody = mapper.writeValueAsString(reviewChanged);
+
+        when(menuItemReviewRepository.findById(eq(67L))).thenReturn(Optional.empty());
+
+        // act
+        MvcResult response = mockMvc.perform(
+                put("/api/MenuItemReview?id=67")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .characterEncoding("utf-8")
+                        .content(requestBody)
+                        .with(csrf()))
+                .andExpect(status().isNotFound()).andReturn();
+
+        // assert
+        verify(menuItemReviewRepository, times(1)).findById(67L);
+        Map<String, Object> json = responseToJson(response);
+        assertEquals("MenuItemReview with id 67 not found", json.get("message"));
+    }
 
   // -------------------------------------------------------------------------
   // Tests for POST /api/MenuItemReview/post


### PR DESCRIPTION
This PR implements the PUT endpoint for MenuItemReview, allowing admins to update existing records.

### Changes:
* Added `updateMenuItemReview` to the controller.
* Added unit tests for success and 404 cases.
* Verified 100% JaCoCo and Pitest coverage locally.

Closes #29 