### PR TITLE
jy - ucsb dining commons menu item controller

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemController.java
@@ -1,0 +1,67 @@
+package edu.ucsb.cs156.example.controllers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "UCSBDiningCommonsMenuItem")
+@RequestMapping("/api/ucsbdiningcommonsmenuitem")
+@RestController
+@Slf4j
+public class UCSBDiningCommonsMenuItemController extends ApiController {
+
+  @Autowired UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  /**
+   * List all UCSB Dining Commons Menu Item
+   *
+   * @return an iterable of UCSB Dining Common Menu items
+   */
+  @Operation(summary = "List all ucsb dining commons menu item")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/all")
+  public Iterable<UCSBDiningCommonsMenuItem> allUCSBDiningCommonsMenuItem() {
+    Iterable<UCSBDiningCommonsMenuItem> diningcommonsmenuitem =
+        ucsbDiningCommonsMenuItemRepository.findAll();
+    return diningcommonsmenuitem;
+  }
+
+  /**
+   * Creates a new menu item
+   *
+   * @param diningCommonsCode dining commons code
+   * @param name item name
+   * @param station serving station
+   * @return a saved menu item
+   */
+  @Operation(summary = "Create a new UCSB Dining Commons Menu Item")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @PostMapping("/post")
+  public UCSBDiningCommonsMenuItem postUCSBDiningCommonsMenuItem(
+      @Parameter(name = "diningCommonsCode") @RequestParam String diningCommonsCode,
+      @Parameter(name = "name") @RequestParam String name,
+      @Parameter(name = "station") @RequestParam String station)
+      throws JsonProcessingException {
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem = new UCSBDiningCommonsMenuItem();
+    ucsbDiningCommonsMenuItem.setDiningCommonsCode(diningCommonsCode);
+    ucsbDiningCommonsMenuItem.setName(name);
+    ucsbDiningCommonsMenuItem.setStation(station);
+
+    UCSBDiningCommonsMenuItem savedUcsbDiningCommonsMenuItem =
+        ucsbDiningCommonsMenuItemRepository.save(ucsbDiningCommonsMenuItem);
+
+    return savedUcsbDiningCommonsMenuItem;
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
+++ b/src/main/java/edu/ucsb/cs156/example/entities/UCSBDiningCommonsMenuItem.java
@@ -1,0 +1,25 @@
+package edu.ucsb.cs156.example.entities;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "ucsbdiningcommonsmenuitem")
+public class UCSBDiningCommonsMenuItem {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  private String diningCommonsCode;
+  private String name;
+  private String station;
+}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,8 +1,9 @@
 package edu.ucsb.cs156.example.repositories;
 
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UCSBDiningCommonsMenuItemRepository
-    extends CrudRepository<UCSBDiningCommonsMenuItemRepository, Long> {}
+    extends CrudRepository<UCSBDiningCommonsMenuItem, Long> {}

--- a/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
+++ b/src/main/java/edu/ucsb/cs156/example/repositories/UCSBDiningCommonsMenuItemRepository.java
@@ -1,0 +1,8 @@
+package edu.ucsb.cs156.example.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UCSBDiningCommonsMenuItemRepository
+    extends CrudRepository<UCSBDiningCommonsMenuItemRepository, Long> {}

--- a/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
+++ b/src/main/resources/db/migration/changes/UCSBDiningCommonsMenuItem.json
@@ -1,0 +1,62 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "UCSBDiningCommonsMenuItem-1",
+          "author": "jayyeung5",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "UCSBDININGCOMMONSMENUITEM"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "UCSBDININGCOMMONSMENUITEM_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "DINING_COMMONS_CODE",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "NAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "STATION",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "UCSBDININGCOMMONSMENUITEM"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBDiningCommonsMenuItemControllerTests.java
@@ -1,0 +1,151 @@
+package edu.ucsb.cs156.example.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import edu.ucsb.cs156.example.ControllerTestCase;
+import edu.ucsb.cs156.example.entities.UCSBDiningCommonsMenuItem;
+import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsMenuItemRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MvcResult;
+
+@WebMvcTest(controllers = UCSBDiningCommonsMenuItemController.class)
+@Import(TestConfig.class)
+public class UCSBDiningCommonsMenuItemControllerTests extends ControllerTestCase {
+
+  @MockitoBean UCSBDiningCommonsMenuItemRepository ucsbDiningCommonsMenuItemRepository;
+
+  @MockitoBean UserRepository userRepository;
+
+  // Authorization tests for /api/ucsbdiningcommonsmenuitem/admin/all
+
+  @Test
+  public void logged_out_users_cannot_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+        .andExpect(status().is(403)); // logged out users can't get all
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_users_can_get_all() throws Exception {
+    mockMvc
+        .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+        .andExpect(status().is(200)); // logged
+  }
+
+  // Authorization tests for /api/ucsbdiningcommonsmenuitem/post
+  // (Perhaps should also have these for put and delete)
+
+  @Test
+  public void logged_out_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ucsbdiningcommonsmenuitem/post")
+                .param("diningCommonsCode", "ortega")
+                .param("name", "Chicken Caesar Salad")
+                .param("station", "Entrees")
+                .with(csrf()))
+        .andExpect(status().is(403));
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_regular_users_cannot_post() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/ucsbdiningcommonsmenuitem/post")
+                .param("diningCommonsCode", "ortega")
+                .param("name", "Chicken Caesar Salad")
+                .param("station", "Entrees")
+                .with(csrf()))
+        .andExpect(status().is(403)); // only admins can post
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_ucsbdiningcommonsmenuitem() throws Exception {
+    // arrange
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("DLG")
+            .name("Chicken Bowl")
+            .station("Entrees")
+            .build();
+
+    when(ucsbDiningCommonsMenuItemRepository.save(eq(ucsbDiningCommonsMenuItem1)))
+        .thenReturn(ucsbDiningCommonsMenuItem1);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/ucsbdiningcommonsmenuitem/post")
+                    .param("diningCommonsCode", "DLG")
+                    .param("name", "Chicken Bowl")
+                    .param("station", "Entrees")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).save(ucsbDiningCommonsMenuItem1);
+    String expectedJson = mapper.writeValueAsString(ucsbDiningCommonsMenuItem1);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void logged_in_user_can_get_all_ucsbdiningcommonsmenuitem() throws Exception {
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem1 =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("Ortega")
+            .name("Chicken Caesar Salad")
+            .station("Entrees")
+            .build();
+
+    UCSBDiningCommonsMenuItem ucsbDiningCommonsMenuItem2 =
+        UCSBDiningCommonsMenuItem.builder()
+            .diningCommonsCode("DLG")
+            .name("Chicken Bowl")
+            .station("Entrees")
+            .build();
+
+    ArrayList<UCSBDiningCommonsMenuItem> expectedDiningCommonsMenuItem = new ArrayList<>();
+    expectedDiningCommonsMenuItem.addAll(
+        Arrays.asList(ucsbDiningCommonsMenuItem1, ucsbDiningCommonsMenuItem2));
+
+    when(ucsbDiningCommonsMenuItemRepository.findAll()).thenReturn(expectedDiningCommonsMenuItem);
+
+    // act
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/ucsbdiningcommonsmenuitem/all"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    // assert
+
+    verify(ucsbDiningCommonsMenuItemRepository, times(1)).findAll();
+    String expectedJson = mapper.writeValueAsString(expectedDiningCommonsMenuItem);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+}


### PR DESCRIPTION
Closes #9 

This PR creates a new JPA entity for dining commons menu items with diningCommonsCode, name, and station. It also added CRUD operations of GET(/all) and POST. It also implemented the UCSBDiningCommonsMenuItemController with the GET(/all) and POST operations available to users and admins, respectively. 

This was tested with Javoco and mutation testing:
<img width="1221" height="537" alt="Screenshot 2026-04-25 at 11 56 31 PM" src="https://github.com/user-attachments/assets/2b1a32b6-95e9-4a2d-9a69-e5edf64ffedf" />
<img width="1512" height="503" alt="Screenshot 2026-04-25 at 11 56 41 PM" src="https://github.com/user-attachments/assets/94095e94-3dd3-4ff0-8f8f-f42bed5c647f" />

And the endpoints were tested on the dokku deployed site:
<img width="1510" height="900" alt="Screenshot 2026-04-25 at 11 57 12 PM" src="https://github.com/user-attachments/assets/6f544ef4-5887-4c03-9b02-027532e18b49" />
